### PR TITLE
Require Python Interpreter component for CMake to discover Python components in virtual environments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(py39compiler LANGUAGES CXX C)
 set(CMAKE_CXX_STANDARD 20 CACHE STRING "C++ statndard to conform to")
 set(CMAKE_C_STANDARD 17 CACHE STRING "C statndard to conform to")
 
-find_package(Python 3.9 EXACT REQUIRED COMPONENTS Development.Embed)
+find_package(Python 3.9 EXACT REQUIRED COMPONENTS Interpreter Development.Embed)
 
 if(MSVC)
     set(LLVM_DIR "C:\\llvm-project\\build_vs_2022\\lib\\cmake\\llvm")


### PR DESCRIPTION
CMake's FindPython module supports Python virtual environments starting from version 3.15. To properly discover the Development component, CMake requires the Interpreter component to be explicitly specified.
https://cmake.org/cmake/help/latest/module/FindPython.html#:~:text=for%20conda%20environments.-,Note,may%20be%20helpful.,-Python_FIND_IMPLEMENTATIONS

Both Linux and Windows installation scripts already include Python interpreter installation, so this change doesn't require any modifications to the install scripts.
