### PR TITLE
Use separate result variables for different branches of IfOp

### DIFF
--- a/include/MLIRGen.h
+++ b/include/MLIRGen.h
@@ -200,6 +200,8 @@ private:
     }
     case If_kind: {
       mlir::LogicalResult result = mlir::success();
+      mlir::LogicalResult ifResult = mlir::success();
+      mlir::LogicalResult elseResult = mlir::success();
       auto valueOrError = mlirGen(statement->v.If.test);
       if (mlir::failed(valueOrError))
         return mlir::failure();
@@ -212,7 +214,7 @@ private:
           [&](mlir::OpBuilder &b, mlir::Location loc) {
             ifElseVariables.push(std::set<llvm::StringRef>());
 
-            result = mlirGen(statement->v.If.body);
+            ifResult = mlirGen(statement->v.If.body);
 
             varsSet = ifElseVariables.top();
             llvm::SmallVector<mlir::Value> returnValues;
@@ -230,14 +232,14 @@ private:
           [&](mlir::OpBuilder &b, mlir::Location loc) {
             ifElseVariables.push(std::set<llvm::StringRef>());
 
-            result = mlirGen(statement->v.If.orelse);
+            elseResult = mlirGen(statement->v.If.orelse);
 
             auto elseVars = ifElseVariables.top();
             if (varsSet != elseVars) {
               mlir::emitError(loc, "Assigned variables in 'if' region {")
                   << varsSet << "} are different than in 'else' region {"
                   << elseVars << "}\n";
-              result = mlir::failure();
+              elseResult = mlir::failure();
             }
             llvm::SmallVector<mlir::Value> returnValues;
             for (auto it = elseVars.begin(); it != elseVars.end(); it++) {
@@ -248,7 +250,7 @@ private:
             ifElseVariables.pop();
             b.create<mlir::scf::YieldOp>(loc, returnValues);
           }); // builder.create<mlir::scf::IfOp>
-      if (mlir::failed(result))
+      if (mlir::failed(ifResult) || mlir::failed(elseResult))
         return mlir::failure();
       // write returned values to symbol table
       for (size_t i = 0; i < resultVarsVector.size(); i++) {


### PR DESCRIPTION
The variable `result` is currently used to store the generation success status for both branches of the IfOp. This can lead to incorrect behavior because it retains the value of the last-processed branch.
If an error occurs during the generation of the then branch, but the else branch succeeds, result will still indicate success, masking the error. The verifier later catches this error.
```py
if True:
    c = 0
    if True:
        c = 7
    else:
        c = 2
        c = 3 + 2
else:
    c = 1
    if True:
        c = 7
    else:
        c = 3
```
```
loc("":1:0): error: operand #0 does not dominate this use
loc("":0:0): error: Module verification failed!
"builtin.module"() ({
  "llvm.func"() <{CConv = #llvm.cconv<ccc>, function_type = !llvm.func<i32 ()>, linkage = #llvm.linkage<external>, sym_name = "main", visibility_ = 0 : i64}> ({
    %0 = "llvm.mlir.constant"() <{value = true}> : () -> i1
    %1 = "scf.if"(%0) ({
      %8 = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
      %9 = "llvm.mlir.constant"() <{value = true}> : () -> i1
      %10 = "scf.if"(%9) ({
        %12 = "llvm.mlir.constant"() <{value = 7 : i64}> : () -> i64
        "scf.yield"(%12) : (i64) -> ()
      }, {
        %11 = "llvm.mlir.constant"() <{value = 2 : i64}> : () -> i64
        "scf.yield"(%11) : (i64) -> ()
      }) : (i1) -> i64
      "scf.yield"(%11) : (i64) -> ()
    }, {
      %3 = "llvm.mlir.constant"() <{value = 1 : i64}> : () -> i64
      %4 = "llvm.mlir.constant"() <{value = true}> : () -> i1
      %5 = "scf.if"(%4) ({
        %7 = "llvm.mlir.constant"() <{value = 7 : i64}> : () -> i64
        "scf.yield"(%7) : (i64) -> ()
      }, {
        %6 = "llvm.mlir.constant"() <{value = 3 : i64}> : () -> i64
        "scf.yield"(%6) : (i64) -> ()
      }) : (i1) -> i64
      "scf.yield"(%5) : (i64) -> ()
    }) : (i1) -> i64
    %2 = "llvm.mlir.constant"() <{value = 0 : i32}> : () -> i32
    "llvm.return"(%2) : (i32) -> ()
  }) : () -> ()
}) : () -> ()
```
If the branch order were reversed, the failure would be detected earlier.
```py
if True:
    c = 1
    if True:
        c = 7
    else:
        c = 3
else:
    c = 0
    if True:
        c = 7
    else:
        c = 2
        c = 3 + 2
```
```
loc("":13:12): error: Not supported expr->kind = 
```


